### PR TITLE
create a container, to simplify local execution

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,35 @@
+# Use Node.js as the base image
+FROM node:23.6.1 AS builder
+
+# Set the working directory
+WORKDIR /app
+
+# Copy package.json and package-lock.json
+COPY package*.json ./
+
+# Install dependencies
+RUN npm install
+
+# Copy the rest of the application code
+COPY . .
+
+# Build the application
+RUN npm run build
+
+# Production stage
+FROM node:23.6.1-alpine AS runner
+
+# Set working directory
+WORKDIR /app
+
+# Copy only necessary files from the build stage
+COPY --from=builder /app/package*.json ./
+COPY --from=builder /app/.next ./.next
+COPY --from=builder /app/node_modules ./node_modules
+
+
+# Expose the application port
+EXPOSE 3000
+
+# Command to run the application
+CMD ["npm", "run", "start"]

--- a/README.md
+++ b/README.md
@@ -20,6 +20,21 @@ You can start editing the page by modifying `app/page.tsx`. The page auto-update
 
 This project uses [`next/font`](https://nextjs.org/docs/app/building-your-application/optimizing/fonts) to automatically optimize and load [Geist](https://vercel.com/font), a new font family for Vercel.
 
+## Run via Docker
+If you only want to run the project without the need to install development tools like npm locally, you can use the following command to create a container:
+
+```bash
+docker build -t evcc-tesla-api-helper .
+```
+
+This creates a container `evcc-tesla-api-helper`. Run it via 
+
+```bash
+docker run -p 3000:3000 evcc-tesla-api-helper
+```
+
+Now, you can access the UI via [http://localhost:3000](http://localhost:3000).
+
 ## Learn More
 
 To learn more about Next.js, take a look at the following resources:


### PR DESCRIPTION
I've added a Dockerfile and description in Readme. Hopefully this makes it easier to use for non-developer people who don't have npm installed. We could also push the resulting image to docker hub to simplify it even more.